### PR TITLE
Add CLI flags parsing and --dry_run, --repo, --single_pr

### DIFF
--- a/src/label_approved/cli.py
+++ b/src/label_approved/cli.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import os
 import sys
@@ -144,6 +145,9 @@ def process_pr(g_h: Github, p_r: PullRequest, *, dry_run: bool = False) -> None:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="nixpkgs PR approvals labeler")
+    parser.add_argument("--dry_run", action="store_true")
+    args = parser.parse_args()
 
     g_h = Github(ghtoken())
     query: list[str] = [
@@ -163,11 +167,12 @@ def main() -> None:
     ]
     pulls = g_h.search_issues(query=" ".join(query))
 
-    dry_run = False
+    if args.dry_run:
+        logging.warning("Running in dry run mode, no changes will be applied")
 
     logging.info("Pulls total: %s", pulls.totalCount)
     for p_r_as_issue in pulls:
-        process_pr(g_h, p_r_as_issue.as_pull_request(), dry_run=dry_run)
+        process_pr(g_h, p_r_as_issue.as_pull_request(), dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/src/label_approved/cli.py
+++ b/src/label_approved/cli.py
@@ -151,32 +151,39 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="nixpkgs PR approvals labeler")
     parser.add_argument("--dry_run", action="store_true")
     parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--single_pr", type=int, help="Run on a single PR instead of crawling the repository")
     args = parser.parse_args()
 
     g_h = Github(ghtoken())
-    query: list[str] = [
-        # "author:r-ryantm",
-        #'label:"10.rebuild-linux: 1-10"',
-        #'-label:"10.rebuild-linux: 1-10"'
-        #'label:"12.approvals: 1"',
-        #'-label:"12.approvals: 2"',
-        #'-label:"12.approvals: 3+',
-        # "base:staging",
-        # "sort:updated-desc",
-        # "sort:created-desc",
-        "draft:false",
-        "is:pr",
-        "is:open",
-        f"repo:{args.repo}",
-    ]
-    pulls = g_h.search_issues(query=" ".join(query))
 
     if args.dry_run:
         logging.warning("Running in dry run mode, no changes will be applied")
 
-    logging.info("Pulls total: %s", pulls.totalCount)
-    for p_r_as_issue in pulls:
-        process_pr(g_h, p_r_as_issue.as_pull_request(), dry_run=args.dry_run)
+    if args.single_pr is not None:
+        repo = g_h.get_repo(args.repo)
+        p_r = repo.get_pull(args.single_pr)
+        process_pr(g_h, p_r, dry_run=args.dry_run)
+    else:
+        query: list[str] = [
+            # "author:r-ryantm",
+            #'label:"10.rebuild-linux: 1-10"',
+            #'-label:"10.rebuild-linux: 1-10"'
+            #'label:"12.approvals: 1"',
+            #'-label:"12.approvals: 2"',
+            #'-label:"12.approvals: 3+',
+            # "base:staging",
+            # "sort:updated-desc",
+            # "sort:created-desc",
+            "draft:false",
+            "is:pr",
+            "is:open",
+            f"repo:{args.repo}",
+        ]
+        pulls = g_h.search_issues(query=" ".join(query))
+
+        logging.info("Pulls total: %s", pulls.totalCount)
+        for p_r_as_issue in pulls:
+            process_pr(g_h, p_r_as_issue.as_pull_request(), dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/src/label_approved/cli.py
+++ b/src/label_approved/cli.py
@@ -11,6 +11,9 @@ from github.Commit import Commit
 from github.PullRequest import PullRequest
 
 
+DEFAULT_REPO = "NixOS/nixpkgs"
+
+
 def ghtoken() -> Optional[str]:
     token = os.getenv("GITHUB_BOT_TOKEN")
     if not token:
@@ -147,6 +150,7 @@ def process_pr(g_h: Github, p_r: PullRequest, *, dry_run: bool = False) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="nixpkgs PR approvals labeler")
     parser.add_argument("--dry_run", action="store_true")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
     args = parser.parse_args()
 
     g_h = Github(ghtoken())
@@ -163,7 +167,7 @@ def main() -> None:
         "draft:false",
         "is:pr",
         "is:open",
-        "repo:NixOS/nixpkgs",
+        f"repo:{args.repo}",
     ]
     pulls = g_h.search_issues(query=" ".join(query))
 


### PR DESCRIPTION
- `--dry_run`: Same dry run mode as before, but without requiring a code edit.
- `--repo`: Defaults to nixpkgs as before.
- `--single_pr`: Takes a PR id integer and runs the labeler on just that PR instead of crawling the whole repo.

Ref #11.