### PR TITLE
Always compare maintainer usernames lowercased.

### DIFF
--- a/src/label_approved/cli.py
+++ b/src/label_approved/cli.py
@@ -142,7 +142,7 @@ def process_pr(g_h: Github, p_r: PullRequest, *, dry_run: bool = False) -> None:
     maintainers: list[str] = get_maintainers(g_h, last_commit)
 
     for a_u in approvals.keys():
-        if a_u.login in maintainers:
+        if a_u.login.lower() in maintainers:
             logging.info("Adding label '12.approved-by: package-maintainer' to PR: '%s' %s", p_r_num, p_r_url)
             if not dry_run:
                 pr_object.p_r.add_to_labels("12.approved-by: package-maintainer")


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/291243, despite the maintainer giving approval, the PR did not receive a label showing it was approved by the package maintainer.

@lilyinstarlight diagnosed this as being due to case sensitivity.  Ofborg maintainer enumeration forcibly lowercases all names (https://github.com/NixOS/ofborg/blob/eb120ff74c155c990b4f0987649cf4b541d7a17b/ofborg/src/maintainers.nix#L91).  Therefore, the username "thra11" in the Gist was compared for equality to "Thra11" from the PullRequest.

Therefore, this change forces the PR name to lowercase.